### PR TITLE
replace hard coded db with snowflake target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,11 @@ jobs:
           name: Rename dbt models
           command: |
             . venv/bin/activate
-            model_suffix=`date +%s`
-            mv ./integration_tests/models/test_model_table.sql ./integration_tests/models/test_model_table_`echo $model_suffix`.sql
-            mv ./integration_tests/models/test_model_view.sql ./integration_tests/models/test_model_view_`echo $model_suffix`.sql
-            sed -i -e "s/test_model_table/test_model_table_$model_suffix/g" ./integration_tests/models/properties.yml
-            sed -i -e "s/test_model_view/test_model_view_$model_suffix/g" ./integration_tests/models/properties.yml
+            export GLOBAL_MODEL_SUFFIX=`date +%s`
+            mv ./integration_tests/models/test_model_table.sql ./integration_tests/models/test_model_table_`echo $GLOBAL_MODEL_SUFFIX`.sql
+            mv ./integration_tests/models/test_model_view.sql ./integration_tests/models/test_model_view_`echo $GLOBAL_MODEL_SUFFIX`.sql
+            sed -i -e "s/test_model_table/test_model_table_$GLOBAL_MODEL_SUFFIX/g" ./integration_tests/models/properties.yml
+            sed -i -e "s/test_model_view/test_model_view_$GLOBAL_MODEL_SUFFIX/g" ./integration_tests/models/properties.yml
       - run:
           name: Install dbt dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ jobs:
             model_suffix=`date +%s`
             mv ./integration_tests/models/test_model_table.sql ./integration_tests/models/test_model_table_`echo $model_suffix`.sql
             mv ./integration_tests/models/test_model_view.sql ./integration_tests/models/test_model_view_`echo $model_suffix`.sql
-            sed -i '' -e "s/test_model_table/test_model_table_$model_suffix/g" ./integration_tests/models/properties.yml
-            sed -i '' -e "s/test_model_view/test_model_view_$model_suffix/g" ./integration_tests/models/properties.yml
+            sed -i -e "s/test_model_table/test_model_table_$model_suffix/g" ./integration_tests/models/properties.yml
+            sed -i -e "s/test_model_view/test_model_view_$model_suffix/g" ./integration_tests/models/properties.yml
       - run:
           name: Install dbt dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: |
             . venv/bin/activate
             export GLOBAL_MODEL_SUFFIX=`date +%s`
-            echo 'export GLOBAL_MODEL_SUFFIX=$GLOBAL_MODEL_SUFFIX' >> "$BASH_ENV"
+            touch .env && echo 'GLOBAL_MODEL_SUFFIX=$GLOBAL_MODEL_SUFFIX' >> .env
             mv ./integration_tests/models/test_model_table.sql ./integration_tests/models/test_model_table_`echo $GLOBAL_MODEL_SUFFIX`.sql
             mv ./integration_tests/models/test_model_view.sql ./integration_tests/models/test_model_view_`echo $GLOBAL_MODEL_SUFFIX`.sql
             sed -i -e "s/test_model_table/test_model_table_$GLOBAL_MODEL_SUFFIX/g" ./integration_tests/models/properties.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,15 @@ jobs:
             pip install -U pip setuptools wheel
             pip install -r dev-requirements.txt
       - run:
+          name: Rename dbt models
+          command: |
+            . venv/bin/activate
+            model_suffix=`date +%s`
+            mv ./integration_tests/models/test_model_table.sql ./integration_tests/models/test_model_table_`echo $model_suffix`.sql
+            mv ./integration_tests/models/test_model_view.sql ./integration_tests/models/test_model_view_`echo $model_suffix`.sql
+            sed -i '' -e "s/test_model_table/test_model_table_$model_suffix/g" ./integration_tests/models/properties.yml
+            sed -i '' -e "s/test_model_view/test_model_view_$model_suffix/g" ./integration_tests/models/properties.yml
+      - run:
           name: Install dbt dependencies
           command: |
             . venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           command: |
             . venv/bin/activate
             export GLOBAL_MODEL_SUFFIX=`date +%s`
+            echo 'export GLOBAL_MODEL_SUFFIX="$GLOBAL_MODEL_SUFFIX"' >> "$BASH_ENV"
             mv ./integration_tests/models/test_model_table.sql ./integration_tests/models/test_model_table_`echo $GLOBAL_MODEL_SUFFIX`.sql
             mv ./integration_tests/models/test_model_view.sql ./integration_tests/models/test_model_view_`echo $GLOBAL_MODEL_SUFFIX`.sql
             sed -i -e "s/test_model_table/test_model_table_$GLOBAL_MODEL_SUFFIX/g" ./integration_tests/models/properties.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: |
             . venv/bin/activate
             export GLOBAL_MODEL_SUFFIX=`date +%s`
-            touch .env && echo 'GLOBAL_MODEL_SUFFIX=$GLOBAL_MODEL_SUFFIX' >> .env
+            touch .env && echo "GLOBAL_MODEL_SUFFIX=$GLOBAL_MODEL_SUFFIX" >> .env
             mv ./integration_tests/models/test_model_table.sql ./integration_tests/models/test_model_table_`echo $GLOBAL_MODEL_SUFFIX`.sql
             mv ./integration_tests/models/test_model_view.sql ./integration_tests/models/test_model_view_`echo $GLOBAL_MODEL_SUFFIX`.sql
             sed -i -e "s/test_model_table/test_model_table_$GLOBAL_MODEL_SUFFIX/g" ./integration_tests/models/properties.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: |
             . venv/bin/activate
             export GLOBAL_MODEL_SUFFIX=`date +%s`
-            echo 'export GLOBAL_MODEL_SUFFIX="$GLOBAL_MODEL_SUFFIX"' >> "$BASH_ENV"
+            echo 'export GLOBAL_MODEL_SUFFIX=$GLOBAL_MODEL_SUFFIX' >> "$BASH_ENV"
             mv ./integration_tests/models/test_model_table.sql ./integration_tests/models/test_model_table_`echo $GLOBAL_MODEL_SUFFIX`.sql
             mv ./integration_tests/models/test_model_view.sql ./integration_tests/models/test_model_view_`echo $GLOBAL_MODEL_SUFFIX`.sql
             sed -i -e "s/test_model_table/test_model_table_$GLOBAL_MODEL_SUFFIX/g" ./integration_tests/models/properties.yml

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,4 @@ dbt-bigquery
 dbt-snowflake
 pytest
 google-cloud-bigquery
-snowflake-connector-python==2.7.9
+snowflake-connector-python==2.8.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,6 @@ dbt-postgres
 dbt-bigquery
 dbt-snowflake
 pytest
+python-dotenv
 google-cloud-bigquery
 snowflake-connector-python==2.8.1

--- a/macros/common/generate_select_logs_query.sql
+++ b/macros/common/generate_select_logs_query.sql
@@ -66,7 +66,7 @@
             query_id,
             query_text
         from
-            table(dbt_model_usage.information_schema.query_history(result_limit => 10000))
+            table({{ target_model.database }}.information_schema.query_history(result_limit => 10000))
         where
             query_type = 'SELECT'
             and start_time between timestampadd({{ time_unit }}, -{{ num_units }}, current_timestamp()) and current_timestamp()

--- a/scripts/query_database.py
+++ b/scripts/query_database.py
@@ -1,3 +1,5 @@
+from dotenv import load_dotenv
+load_dotenv()
 import os
 import sys
 import snowflake.connector

--- a/scripts/query_database.py
+++ b/scripts/query_database.py
@@ -5,14 +5,14 @@ from google.cloud import bigquery
 
 QUERIES = {
     'models_query': """
-        select * from {0}.{1}.test_model_view
+        select * from {0}.{1}.test_model_view_{2}
         union all
-        select * from {0}.{1}.test_model_table
+        select * from {0}.{1}.test_model_table_{2}
         """,
 
     'columns_query': """
         select string_field 
-        from {0}.{1}.test_model_view
+        from {0}.{1}.test_model_view_{2}
         """
 }
 
@@ -24,7 +24,8 @@ def main(target, query_name):
         bigquery_ctx = bigquery.Client()
         query = query_format_string.format(
             os.getenv('BIGQUERY_TEST_DATABASE'),
-            os.getenv('TEST_SCHEMA')
+            os.getenv('TEST_SCHEMA'),
+            os.getenv('GLOBAL_MODEL_SUFFIX')
         )
         print(f"{query}\n")
         _ = bigquery_ctx.query(query).result()
@@ -36,7 +37,9 @@ def main(target, query_name):
             account=os.getenv('SNOWFLAKE_ACCOUNT_ID'))
         query = query_format_string.format(
             os.getenv('SNOWFLAKE_TEST_DATABASE'),
-            os.getenv('TEST_SCHEMA'))
+            os.getenv('TEST_SCHEMA'),
+            os.getenv('GLOBAL_MODEL_SUFFIX')
+        )
         print(f"{query}\n")
         cur = snowflake_ctx.cursor()
         cur.execute(query)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -18,7 +18,7 @@ printf "\n\nRunning integration test query:"
 python3 ./scripts/query_database.py $dbt_target models_query
 
 printf "\n\ndbt test ...\n"
-dbt test -t $dbt_target --project-dir $DBT_PROJECT_DIR --vars '{time_unit: second, num_units: 60}' || true
+dbt test -t $dbt_target --project-dir $DBT_PROJECT_DIR --vars '{time_unit: second, num_units: 30}' || true
 printf "\nRun results validation:\n"
 pytest -v scripts/test_run_results.py::test_build_failure_column_test
 
@@ -26,6 +26,6 @@ printf "\n\nRunning integration test query:"
 python3 ./scripts/query_database.py $dbt_target columns_query
 
 printf "\n\ndbt test ...\n"
-dbt test -t $dbt_target --project-dir $DBT_PROJECT_DIR --vars '{time_unit: hour, num_units: 1}'
+dbt test -t $dbt_target --project-dir $DBT_PROJECT_DIR --vars '{time_unit: second, num_units: 40}'
 printf "\nRun results validation:\n"
 pytest -v scripts/test_run_results.py::test_build_success


### PR DESCRIPTION
resolves #1 

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
This fixes a typo in the prior release where target db for the query that generates snowflake query logs was hard-coded

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)