### PR TITLE
add target model's database

### DIFF
--- a/macros/common/generate_create_logs_query.sql
+++ b/macros/common/generate_create_logs_query.sql
@@ -37,7 +37,7 @@
     select
         ddl as query
     from
-        `{{ target_model.schema }}`.INFORMATION_SCHEMA.TABLES
+        `{{ target_model.database }}`.`{{ target_model.schema }}`.INFORMATION_SCHEMA.TABLES
     WHERE
         table_name = '{{ target_model.name }}'
         and creation_time < timestamp_sub(current_timestamp(), interval {{ num_units }} {{ time_unit }})


### PR DESCRIPTION
resolves #

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

This package has a bug in the sense that it assumes the database used for materializing the models is the database defined in the profile file. This is not the case for us as we override the macros `generate_database_name` and `generate_schema_name`.

Change to be done (might be additional changes to be done):
1. [dbt-model-usage/macros/common/generate_create_logs_query.sql](https://github.com/rjh336/dbt-model-usage/blob/main/macros/common/generate_create_logs_query.sql)
Line 40: 
`{{ target_model.schema }}`.INFORMATION_SCHEMA.TABLES
should be:
`{{ target_model.database }}`.`{{ target_model.schema }}`.INFORMATION_SCHEMA.TABLES

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)